### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show, :edit]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :check_current_user, only:[:edit, :destroy]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :edit]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -37,6 +37,15 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item)
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if user_signed_in?
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to new_user_session_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in? && current_user == @item.user
+    if current_user != @item.user
       @item.destroy
       redirect_to root_path
     else
@@ -59,4 +59,5 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in?
+    if user_signed_in? && current_user == @item.user
       @item.destroy
       redirect_to root_path
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show, :edit]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :check_current_user, only:[:edit, :destroy]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -23,13 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if user_signed_in? && current_user == @item.user
-      render :edit
-    elsif user_signed_in? && current_user != @item.user
-      redirect_to root_path
-    else
-      redirect_to new_user_session_path
-    end
   end
 
   def update
@@ -41,12 +35,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if current_user == @item.user
       @item.destroy
       redirect_to root_path
-    else
-      redirect_to new_user_session_path
-    end
   end
 
   private
@@ -59,5 +49,11 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
+ def check_current_user
+  if user_signed_in? && current_user != @item.user
+    redirect_to root_path
+  end
+ end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,7 +41,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if current_user != @item.user
+    if current_user == @item.user
       @item.destroy
       redirect_to root_path
     else

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update] do
+  resources :items do
   end
 end


### PR DESCRIPTION
# what

- destroyアクションの定義
- 削除パスの追記

# why
商品削除機能の実装

- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/edba2f3fe81dae6c32f6910dfe4b0152
